### PR TITLE
feat: implement Google Calendar event creation tool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,5 @@ serde_json = "1.0.140"
 tokio = { version = "1.45.0", features = ["rt-multi-thread"] }
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
+reqwest = { version = "0.12.11", features = ["json"] }
+chrono = { version = "0.4.40", features = ["serde"] }

--- a/src/google_calendar.rs
+++ b/src/google_calendar.rs
@@ -1,7 +1,33 @@
 use rmcp::model::{ServerCapabilities, ServerInfo};
+use serde::{Deserialize, Serialize};
+use std::env;
 
 #[derive(derive_new::new, Clone)]
 pub struct GoogleCalendar;
+
+#[derive(Serialize, Deserialize)]
+struct GoogleCalendarEvent {
+    summary: String,
+    description: Option<String>,
+    start: EventDateTime,
+    end: EventDateTime,
+}
+
+#[derive(Serialize, Deserialize)]
+struct EventDateTime {
+    #[serde(rename = "dateTime")]
+    date_time: String,
+    #[serde(rename = "timeZone")]
+    time_zone: String,
+}
+
+#[derive(Serialize, Deserialize)]
+struct GoogleCalendarResponse {
+    id: Option<String>,
+    summary: Option<String>,
+    #[serde(rename = "htmlLink")]
+    html_link: Option<String>,
+}
 
 #[rmcp::tool(tool_box)]
 impl GoogleCalendar {
@@ -11,10 +37,77 @@ impl GoogleCalendar {
         "予定一覧のダミーデータ".to_string()
     }
 
-    #[rmcp::tool(description = "新しい予定を追加する")]
-    pub fn add_event(&self) -> String {
-        // TODO: GoogleカレンダーAPI連携実装
-        format!("予定 '{}' を追加しました", "新しい予定")
+    #[rmcp::tool(description = "新しい予定を作成する")]
+    pub async fn create_event(
+        &self,
+        summary: String,
+        description: Option<String>,
+        start_datetime: String,
+        end_datetime: String,
+        timezone: Option<String>,
+    ) -> anyhow::Result<String> {
+        let api_key = env::var("GOOGLE_CALENDAR_API_KEY")
+            .map_err(|_| anyhow::anyhow!("GOOGLE_CALENDAR_API_KEY environment variable not set"))?;
+        
+        let calendar_id = env::var("GOOGLE_CALENDAR_ID")
+            .unwrap_or_else(|_| "primary".to_string());
+        
+        let tz = timezone.unwrap_or_else(|| "Asia/Tokyo".to_string());
+        
+        let event = GoogleCalendarEvent {
+            summary,
+            description,
+            start: EventDateTime {
+                date_time: start_datetime,
+                time_zone: tz.clone(),
+            },
+            end: EventDateTime {
+                date_time: end_datetime,
+                time_zone: tz,
+            },
+        };
+
+        let client = reqwest::Client::new();
+        let url = format!(
+            "https://www.googleapis.com/calendar/v3/calendars/{}/events?key={}",
+            calendar_id, api_key
+        );
+
+        let response = client
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .json(&event)
+            .send()
+            .await?;
+
+        if response.status().is_success() {
+            let created_event: GoogleCalendarResponse = response.json().await?;
+            Ok(format!(
+                "予定 '{}' を作成しました。ID: {}",
+                created_event.summary.unwrap_or_else(|| "Unknown".to_string()),
+                created_event.id.unwrap_or_else(|| "Unknown".to_string())
+            ))
+        } else {
+            let error_text = response.text().await?;
+            Err(anyhow::anyhow!("Google Calendar API error: {}", error_text))
+        }
+    }
+
+    #[rmcp::tool(description = "新しい予定を追加する（簡易版）")]
+    pub async fn add_event(&self, title: String, start_time: String) -> anyhow::Result<String> {
+        // 1時間後を終了時間とする簡易実装
+        let start_dt = chrono::DateTime::parse_from_rfc3339(&start_time)
+            .map_err(|_| anyhow::anyhow!("Invalid start_time format. Use RFC3339 format (e.g., 2023-12-25T10:00:00+09:00)"))?;
+        
+        let end_dt = start_dt + chrono::Duration::hours(1);
+        
+        self.create_event(
+            title,
+            None,
+            start_dt.to_rfc3339(),
+            end_dt.to_rfc3339(),
+            None,
+        ).await
     }
 }
 


### PR DESCRIPTION
Implements Google Calendar event creation functionality as requested in issue #1.

## Changes
- Add reqwest and chrono dependencies
- Implement create_event function with full event creation capabilities
- Add simplified add_event function for quick event creation
- Support environment variables GOOGLE_CALENDAR_API_KEY and GOOGLE_CALENDAR_ID
- Use Google Calendar API v3 for creating events

## Features
- Environment variable configuration for API keys
- Error handling for API requests
- Japanese language support
- Timezone support (defaults to Asia/Tokyo)

Closes #1

Generated with [Claude Code](https://claude.ai/code)